### PR TITLE
Fix navigation and content rendering issues

### DIFF
--- a/apps/website/app/(components)/(blockTypes)/imageSection.tsx
+++ b/apps/website/app/(components)/(blockTypes)/imageSection.tsx
@@ -37,7 +37,7 @@ export default function ImageSection({ value: { asset, alt, emptyAlt } }: Props)
 
 	return (
 		<Image
-			style={{ display: "block", margin: "1rem 0", padding: "o.5rem" }}
+			style={{ display: "block", margin: "1rem 0", padding: "0.5rem" }}
 			src={img2x}
 			alt={altText}
 			width={400}

--- a/apps/website/app/(components)/mainNavItem.tsx
+++ b/apps/website/app/(components)/mainNavItem.tsx
@@ -15,17 +15,22 @@ export default function MainNavItem({
 }: Props) {
 	let url: string;
 	switch (type) {
-		case "page":
-			url = `/${slug?.current}`;
+		case "page": {
+			const currentSlug = slug?.current;
+			url = currentSlug ? `/${currentSlug}` : "/";
 			break;
-		case "recipesPage":
+		}
+		case "recipesPage": {
 			url = "/recipe";
 			break;
-		case "tagsPage":
-			url = "tags";
+		}
+		case "tagsPage": {
+			url = "/tags";
 			break;
-		default:
+		}
+		default: {
 			assertUnreachable(type);
+		}
 	}
 	return (
 		<Link className={styles.mainNavItem} href={url}>

--- a/apps/website/app/(components)/tags.tsx
+++ b/apps/website/app/(components)/tags.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import clsx from "clsx";
 import "server-only";
 import styles from "./(styles)/tags.module.css";
 import Tag from "./tag";
@@ -9,24 +9,23 @@ interface Props {
 	small?: boolean;
 }
 
-export default function Tags({ tags, noMargin }: Props) {
-	const sorted = useMemo(() => [...tags].sort(), [tags]);
+function renderTag(tag: string) {
+	return <Tag tag={tag} key={tag} />;
+}
 
-	const noMarginClass = noMargin === true ? styles.noMargin : null;
-	const mainClass = styles.tagList;
-	const smallClass = styles.small;
-	const className = `${mainClass} ${noMarginClass} ${smallClass}`.trimEnd();
+export default function Tags({ tags, noMargin = false, small = false }: Props) {
+	const sorted = [...tags].sort();
+
+	const className = clsx(styles.tagList, {
+		[styles.noMargin]: noMargin,
+		[styles.small]: small,
+	});
 
 	return (
 		<ul className={className}>
-			{sorted.map((tag) => (
-				<Tag tag={tag} key={tag} />
-			))}
+			{sorted.map((tag) => {
+				return renderTag(tag);
+			})}
 		</ul>
 	);
 }
-
-Tags.defaultProps = {
-	noMargin: false,
-	small: false,
-};

--- a/apps/website/app/(components)/tags.tsx
+++ b/apps/website/app/(components)/tags.tsx
@@ -9,10 +9,6 @@ interface Props {
 	small?: boolean;
 }
 
-function renderTag(tag: string) {
-	return <Tag tag={tag} key={tag} />;
-}
-
 export default function Tags({ tags, noMargin = false, small = false }: Props) {
 	const sorted = [...tags].sort();
 
@@ -24,7 +20,7 @@ export default function Tags({ tags, noMargin = false, small = false }: Props) {
 	return (
 		<ul className={className}>
 			{sorted.map((tag) => {
-				return renderTag(tag);
+				return <Tag tag={tag} key={tag} />;
 			})}
 		</ul>
 	);

--- a/apps/website/app/recipe/[slug]/(components)/steps.tsx
+++ b/apps/website/app/recipe/[slug]/(components)/steps.tsx
@@ -14,6 +14,10 @@ export default async function Steps({ params }: { params: { slug: string } | Pro
 	}
 
 	function getIngredientsForIndex(index: number) {
+		if (!ingredients || ingredients.length === 0) {
+			return [];
+		}
+
 		return ingredients.filter(({ usedInSteps }) => {
 			const usedSteps = usedInSteps ?? [];
 			return usedSteps.indexOf(index + 1) > -1;

--- a/apps/website/app/recipe/[slug]/(components)/steps.tsx
+++ b/apps/website/app/recipe/[slug]/(components)/steps.tsx
@@ -13,8 +13,12 @@ export default async function Steps({ params }: { params: { slug: string } | Pro
 		return null;
 	}
 
-	const getIngredientsForIndex = (index: number) =>
-		ingredients.filter(({ usedInSteps }) => (usedInSteps?.indexOf(index + 1) ?? -1) > -1);
+	function getIngredientsForIndex(index: number) {
+		return ingredients.filter(({ usedInSteps }) => {
+			const usedSteps = usedInSteps ?? [];
+			return usedSteps.indexOf(index + 1) > -1;
+		});
+	}
 
 	return (
 		<>

--- a/apps/website/hooks/useTime.ts
+++ b/apps/website/hooks/useTime.ts
@@ -1,10 +1,5 @@
-import { useMemo } from "react";
-
 export default function useTime(totalMinutes: number): { minutes: number; hours: number } {
-	const time = useMemo(() => {
-		const hours = Math.floor(totalMinutes / 60);
-		const minutes = totalMinutes % 60;
-		return { hours, minutes };
-	}, [totalMinutes]);
-	return time;
+	const hours = Math.floor(totalMinutes / 60);
+	const minutes = totalMinutes % 60;
+	return { hours, minutes };
 }

--- a/apps/website/next-env.d.ts
+++ b/apps/website/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/website/next-env.d.ts
+++ b/apps/website/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/website/queries/getRecipeBySlug.ts
+++ b/apps/website/queries/getRecipeBySlug.ts
@@ -29,9 +29,5 @@ export default async function getRecipeBySlug(slug: string): Promise<Recipe> {
 		console.warn(`Got more than one recipe with slug ${slug}. Using the first.`, { slug, result });
 	}
 
-	if (result.length === 0) {
-		throwError(`Could not find recipe with slug: ${slug}`);
-	}
-
 	return result[0];
 }

--- a/apps/website/queries/lib/buildGroqQuery.ts
+++ b/apps/website/queries/lib/buildGroqQuery.ts
@@ -3,7 +3,7 @@ import { clientEnv } from "shared/config/env.client";
 const siteKey = clientEnv.NEXT_PUBLIC_SANITY_KEY;
 const dataset = clientEnv.NEXT_PUBLIC_SANITY_DATASET;
 
-const baseAddress = `https://${siteKey}.api.sanity.io/v2021-10-21/data/query/${dataset}`;
+const baseAddress = `https://${siteKey}.api.sanity.io/v2023-08-01/data/query/${dataset}`;
 
 export default function buildGroqQuery(groq: string) {
 	const encodedQuery = encodeURIComponent(groq);


### PR DESCRIPTION
## Summary
- Update the Sanity GROQ query builder to use the current v2023-08-01 endpoint
- Fix navigation and tags rendering logic, including correct URLs and class handling
- Simplify supporting helpers and clean up rendering (useTime, step ingredient selection, inline image padding, redundant slug checks)

## Testing
- pnpm -w exec biome check apps/website
- pnpm -w exec tsc -p apps/website/tsconfig.json --noEmit *(fails: missing generated @ryan-bakes/sanity-types; schema extract blocked by network proxy)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695725aa82d883209cd83f2301a9f96f)