### PR TITLE
Fix ingredients

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,7 @@ When making changes:
   - When changing things in the Website, test the website (`pnpm run build:website`)
 - Update documentation appropriately:
   - `AGENTS.md`, `ARCHITECTURE.md`, `README.md`
+- For commit comments, follow the conventions laid out in `commitlint.config.mjs`. Add an expanded description with a more complete accounting of the changes.
 
 ## For Humans
 

--- a/apps/website/app/recipe/[slug]/(components)/(styles)/steps.module.css
+++ b/apps/website/app/recipe/[slug]/(components)/(styles)/steps.module.css
@@ -1,0 +1,4 @@
+.ol {
+	padding: 0;
+	list-style: none;
+}

--- a/apps/website/app/recipe/[slug]/(components)/step.tsx
+++ b/apps/website/app/recipe/[slug]/(components)/step.tsx
@@ -27,9 +27,9 @@ export default function Step({ ingredients, step: { title, content }, units }: P
 		<li className={styles.stepWrap}>
 			{ingredients && ingredients.length > 0 && (
 				<ul className={styles.ingredientsWrap}>
-					{ingredients.map(({ _key, amount, unit }) => (
+					{ingredients.map(({ _key, amount, name, unit }) => (
 						<li key={_key}>
-							<IngredientAmount amount={amount ?? ""} units={units} {...(unit ? { unit } : {})} />
+							<IngredientAmount amount={amount ?? ""} units={units} {...(unit ? { unit } : {})} /> &ndash; {name}
 						</li>
 					))}
 				</ul>

--- a/apps/website/app/recipe/[slug]/(components)/steps.tsx
+++ b/apps/website/app/recipe/[slug]/(components)/steps.tsx
@@ -2,6 +2,7 @@ import Heading from "app/(components)/heading";
 import getAllUnits from "queries/getAllUnits";
 import getRecipeBySlug from "queries/getRecipeBySlug";
 import "server-only";
+import styles from "./(styles)/steps.module.css";
 import Step from "./step";
 
 export default async function Steps({ params }: { params: { slug: string } | Promise<{ slug: string }> }) {
@@ -27,7 +28,7 @@ export default async function Steps({ params }: { params: { slug: string } | Pro
 	return (
 		<>
 			<Heading level={3}>Instructions</Heading>
-			<ol>
+			<ol className={styles.ol}>
 				{steps.map((step, i) => (
 					<Step key={step._key} step={step} ingredients={getIngredientsForIndex(i)} units={units} />
 				))}


### PR DESCRIPTION
This pull request improves the display and clarity of recipe steps on the website by updating both the visual styling and the content shown for each step. It also adds a documentation guideline for commit messages.

**Website improvements:**

* Added a new CSS class `.ol` in `steps.module.css` to remove default padding and list styling from ordered lists, and applied this class to the steps list in `steps.tsx` for a cleaner appearance. ([apps/website/app/recipe/[slug]/(components)/(styles)/steps.module.cssR1-R4](diffhunk://#diff-72f272b6dc8b898b79876c690693e15a8cc11b34c243cc27e293a74ad3ce93bfR1-R4), [apps/website/app/recipe/[slug]/(components)/steps.tsxR5](diffhunk://#diff-858f82a5d9ec1ab66677baca77d7bb918b747554e768d1af12b8c6c9bedece33R5), [apps/website/app/recipe/[slug]/(components)/steps.tsxL30-R31](diffhunk://#diff-858f82a5d9ec1ab66677baca77d7bb918b747554e768d1af12b8c6c9bedece33L30-R31))
* Updated the ingredient list in each step to display the ingredient name alongside its amount and unit, improving clarity for users following recipes. ([apps/website/app/recipe/[slug]/(components)/step.tsxL30-R32](diffhunk://#diff-3d73d66271d805ab439793342c0d59dcdcd85540edb1d334f7b02183be9d5958L30-R32))

**Documentation update:**

* Added a note in `AGENTS.md` to follow `commitlint.config.mjs` conventions for commit comments and to provide an expanded description of changes.