### PR TITLE
Refine site color palette

### DIFF
--- a/apps/website/app/(components)/(styles)/mainNav.module.css
+++ b/apps/website/app/(components)/(styles)/mainNav.module.css
@@ -11,7 +11,7 @@
 }
 
 .headerWrap :is(a):hover {
-	text-decoration-color: var(--secondary);
+	text-decoration-color: var(--secondary-dark);
 	transition: text-decoration-color var(--animation-duration) ease-in;
 }
 

--- a/apps/website/app/(components)/(styles)/tag.module.css
+++ b/apps/website/app/(components)/(styles)/tag.module.css
@@ -12,7 +12,7 @@
 
 .tagLink:hover,
 .tagLink:focus-visible {
-	text-decoration-color: var(--secondary);
+	text-decoration-color: var(--secondary-dark);
 }
 
 .tagLink_Svg {

--- a/apps/website/app/recipe/[slug]/(components)/(styles)/ingredients.module.css
+++ b/apps/website/app/recipe/[slug]/(components)/(styles)/ingredients.module.css
@@ -14,7 +14,7 @@
 .ingredientsTable_thead th {
 	text-align: left;
 	padding: 0.25rem 1rem 0.125rem 1rem;
-	border-bottom: 0.1rem solid var(--secondary);
+	border-bottom: 0.1rem solid var(--secondary-dark);
 }
 
 .ingredientsTable_tbody tr:nth-of-type(even) {

--- a/apps/website/app/recipe/[slug]/(components)/(styles)/step.module.css
+++ b/apps/website/app/recipe/[slug]/(components)/(styles)/step.module.css
@@ -24,7 +24,7 @@
 	.stepWrap ul {
 		padding-left: 0.5rem;
 		margin-left: 0.5rem;
-		border-left: 0.1rem solid var(--secondary);
+		border-left: 0.1rem solid var(--secondary-dark);
 	}
 }
 

--- a/apps/website/styles/global.css
+++ b/apps/website/styles/global.css
@@ -107,7 +107,7 @@ p {
 
 a {
 	color: var(--text);
-	text-decoration-color: var(--secondary);
+	text-decoration-color: var(--secondary-dark);
 }
 
 .sr {

--- a/apps/website/styles/variables.css
+++ b/apps/website/styles/variables.css
@@ -2,22 +2,41 @@
 	--max-content-width: 1900px;
 	--line-height: 1.6;
 
-	--text: #000000;
-	--bg: #ffffff;
-	--bg-alt: #f0fdf8;
-	--bg-subtle: linear-gradient(90deg, #eee, #fff);
-	--card-shadow: -2rem 0 3rem -2rem #838a88;
+	/* Neutral ramp for surfaces, borders, and body text */
+	--neutral-50: #f7f8fa;
+	--neutral-100: #eef1f4;
+	--neutral-200: #d8dee6;
+	--neutral-400: #9aa5b5;
+	--neutral-900: #1f2a36;
 
-	--primary: #0d19a3;
-	--primary_r: 13;
-	--primary_g: 25;
-	--primary_b: 163;
+	--text: var(--neutral-900);
+	--bg: var(--neutral-50);
+	--bg-alt: var(--neutral-100);
+	--bg-subtle: linear-gradient(90deg, #eef1f4, #f7f8fa);
+	--card-shadow: -2rem 0 3rem -2rem var(--neutral-400);
+
+	/* Blue primary */
+	--primary: #0c2d57;
+	--primary-light: #e7edf7;
+	--primary-dark: #081c35;
+	--primary_r: 12;
+	--primary_g: 45;
+	--primary_b: 87;
 	--primary-contrast: #ffffff;
-	--secondary: #15db95;
-	--secondary_r: 21;
-	--secondary_g: 219;
-	--secondary_b: 149;
-	--secondary-contrast: #000000;
+
+	/* Jade secondary */
+	--secondary: #2fb37c;
+	--secondary-light: #e4f7ef;
+	--secondary-dark: #1f7b55;
+	--secondary_r: 47;
+	--secondary_g: 179;
+	--secondary_b: 124;
+	--secondary-contrast: #0a110c;
+
+	/* Warm accent for highlights */
+	--accent-warm: #f08a5d;
+
+	/* Feedback */
 	--error: #f57390;
 	--error-contrast: #030e12;
 


### PR DESCRIPTION
## Summary
- add neutral ramp plus light/dark steps for the blue primary and jade secondary palette
- retune global link and navigation hover accents to use darker secondary tones
- adjust recipe component borders to use the refined secondary dark variant

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695748110bbc8320837af4419bfd3d8c)