### PR TITLE
Improve CSS spacing and accessibility refinements

### DIFF
--- a/apps/website/app/(components)/(styles)/featuredRecipe.module.css
+++ b/apps/website/app/(components)/(styles)/featuredRecipe.module.css
@@ -8,7 +8,7 @@
 	grid-template-columns: max-content 1fr;
 	grid-template-rows: min-content min-content 1fr;
 	grid-template-areas: "img title" "img tags" "img blurb";
-	grid-gap: var(--featured-padding);
+	gap: var(--featured-padding);
 	max-height: 350px;
 	overflow: hidden;
 }

--- a/apps/website/app/(components)/(styles)/mainNav.module.css
+++ b/apps/website/app/(components)/(styles)/mainNav.module.css
@@ -7,12 +7,16 @@
 .headerWrap :is(a) {
 	color: var(--primary-contrast);
 	text-decoration-color: transparent;
-	transition: text-decoration-color var(--animation-duration) ease-out;
+	transition: text-decoration-color var(--animation-duration) ease-in-out;
 }
 
-.headerWrap :is(a):hover {
+.headerWrap :is(a:hover, a:focus-visible) {
 	text-decoration-color: var(--secondary);
-	transition: text-decoration-color var(--animation-duration) ease-in;
+}
+
+.headerWrap :is(a:focus-visible) {
+	outline: var(--focus-outline-width) solid var(--focus-outline-color);
+	outline-offset: var(--focus-outline-offset);
 }
 
 .header {
@@ -20,7 +24,7 @@
 	grid-template-columns: max-content 1fr;
 	grid-template-rows: 1fr;
 	grid-template-areas: "title nav";
-	grid-gap: 1rem;
+	gap: 1rem;
 	align-items: center;
 }
 

--- a/apps/website/app/(components)/(styles)/mainNavItem.module.css
+++ b/apps/website/app/(components)/(styles)/mainNavItem.module.css
@@ -8,7 +8,5 @@ a.mainNavItem {
 	a.mainNavItem {
 		font-size: 0.75rem;
 		min-width: 2.2rem;
-		text-align: center;
-		display: block;
 	}
 }

--- a/apps/website/app/(components)/(styles)/tag.module.css
+++ b/apps/website/app/(components)/(styles)/tag.module.css
@@ -8,11 +8,19 @@
 	align-items: center;
 	color: var(--text);
 	text-decoration-color: transparent;
+	transition:
+		color var(--animation-duration) ease-in-out,
+		text-decoration-color var(--animation-duration) ease-in-out;
 }
 
 .tagLink:hover,
 .tagLink:focus-visible {
 	text-decoration-color: var(--secondary);
+}
+
+.tagLink:focus-visible {
+	outline: var(--focus-outline-width) solid var(--focus-outline-color);
+	outline-offset: var(--focus-outline-offset);
 }
 
 .tagLink_Svg {

--- a/apps/website/app/(components)/(styles)/tags.module.css
+++ b/apps/website/app/(components)/(styles)/tags.module.css
@@ -4,6 +4,8 @@
 	flex-flow: row wrap;
 	margin: 0 0 clamp(5vh, 3rem, 50vh);
 	font-size: 0.75rem;
+	list-style: none;
+	gap: 1rem;
 }
 
 .tagList svg {
@@ -16,13 +18,10 @@
 	margin-bottom: 0;
 }
 
-.tagList li + li {
-	margin-left: 1rem;
-}
-
 .tagList.small {
 	flex-flow: row nowrap;
 	font-size: 0.7rem;
+	gap: 0.25rem;
 	overflow-x: hidden;
 }
 
@@ -30,8 +29,4 @@
 	width: 0.8rem;
 	height: 0.8rem;
 	margin-right: 0.1rem;
-}
-
-.tagList.small li + li {
-	margin-left: 0.25rem;
 }

--- a/apps/website/app/recipe/(components)/(styles)/secondaryFeaturedRecipe.module.css
+++ b/apps/website/app/recipe/(components)/(styles)/secondaryFeaturedRecipe.module.css
@@ -2,7 +2,9 @@
 	--card-padding: 0.75rem;
 	width: clamp(12rem, 15rem, 20rem);
 	min-height: 17.5rem;
-	transition: transform var(--animation-duration) ease-in-out;
+	transition:
+		transform var(--animation-duration) ease-in-out,
+		margin-left var(--animation-duration) ease-in-out;
 	transition-delay: 0.1s;
 	background: var(--bg-subtle);
 	box-shadow: var(--card-shadow);

--- a/apps/website/app/recipe/(components)/(styles)/secondaryFeaturedRecipe.module.css
+++ b/apps/website/app/recipe/(components)/(styles)/secondaryFeaturedRecipe.module.css
@@ -2,7 +2,7 @@
 	--card-padding: 0.75rem;
 	width: clamp(12rem, 15rem, 20rem);
 	min-height: 17.5rem;
-	transition: all var(--animation-duration) ease-in-out;
+	transition: transform var(--animation-duration) ease-in-out;
 	transition-delay: 0.1s;
 	background: var(--bg-subtle);
 	box-shadow: var(--card-shadow);
@@ -14,7 +14,7 @@
 	grid-template-columns: 1fr;
 	grid-template-rows: min-content min-content min-content 1fr;
 	grid-template-areas: "pic" "name" "tags" "content";
-	grid-gap: 0.5rem;
+	gap: 0.5rem;
 }
 
 .recipeCard:first-child:hover {
@@ -70,6 +70,17 @@
 
 .content p + p {
 	display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.recipeCard {
+		transition: none;
+	}
+
+	.recipeCard:first-child:hover,
+	.recipeCard:not(:first-child):hover {
+		transform: none;
+	}
 }
 
 @media only screen and (max-width: 640px) {

--- a/apps/website/app/recipe/(components)/(styles)/secondaryFeaturedRecipe.module.css
+++ b/apps/website/app/recipe/(components)/(styles)/secondaryFeaturedRecipe.module.css
@@ -83,6 +83,10 @@
 	.recipeCard:not(:first-child):hover {
 		transform: none;
 	}
+
+	.recipeCard:hover + .recipeCard {
+		margin-left: -5rem;
+	}
 }
 
 @media only screen and (max-width: 640px) {

--- a/apps/website/app/recipe/[slug]/(components)/(styles)/hero.module.css
+++ b/apps/website/app/recipe/[slug]/(components)/(styles)/hero.module.css
@@ -38,6 +38,7 @@
 		--hero-aspectRatio_W: 1;
 		--hero-aspectRatio_H: 1;
 		background-image: var(--bgUrl-tablet);
+		background-attachment: scroll;
 	}
 }
 

--- a/apps/website/app/recipe/[slug]/(components)/(styles)/step.module.css
+++ b/apps/website/app/recipe/[slug]/(components)/(styles)/step.module.css
@@ -4,7 +4,7 @@
 	grid-template-columns: clamp(10vw, 20rem, 50vw) 1fr;
 	grid-template-rows: 1fr;
 	grid-template-areas: "ing step";
-	grid-gap: 2rem;
+	gap: 2rem;
 	align-items: center;
 	background: var(--bg);
 }
@@ -17,7 +17,7 @@
 	.stepWrap {
 		grid-template-columns: 1fr;
 		grid-template-rows: 1fr auto;
-		grid-gap: 1rem;
+		gap: 1rem;
 		grid-template-areas: "step" "ing";
 	}
 

--- a/apps/website/app/recipe/[slug]/(components)/(styles)/subTitle.module.css
+++ b/apps/website/app/recipe/[slug]/(components)/(styles)/subTitle.module.css
@@ -33,7 +33,7 @@
 		display: grid;
 		grid-template-rows: auto;
 		grid-template-columns: max-content 1fr;
-		grid-gap: 0 0.2rem;
+		gap: 0 0.2rem;
 	}
 
 	.dl dd + dt {

--- a/apps/website/styles/global.css
+++ b/apps/website/styles/global.css
@@ -20,6 +20,15 @@ body {
 	background: var(--bg);
 }
 
+@media only screen and (max-width: 660px) {
+	:root {
+		--content-padding-inline: clamp(0.75rem, 3vw, 1.5rem);
+		--content-padding-block-start: clamp(1.25rem, 3vh, 2rem);
+		--content-padding-block-end: clamp(2rem, 6vh, 3rem);
+		--header-footer-padding-inline: clamp(0.75rem, 4vw, 1.5rem);
+	}
+}
+
 :is(h2, h3, h4) {
 	line-height: 1.2;
 }
@@ -80,23 +89,13 @@ footer {
 
 .content {
 	width: 100%;
-	padding: clamp(2rem, 2rem, 50vh) clamp(2rem, 5vw, 3rem) 6rem;
+	padding: var(--content-padding-block-start) var(--content-padding-inline) var(--content-padding-block-end);
 	min-height: 100vh;
-}
-
-@media only screen and (max-width: 660px) {
-	.content {
-		padding: clamp(2vh, 2rem, 50vh) clamp(0.5rem, 1vw, 3rem) 3rem;
-	}
 }
 
 header,
 footer {
-	padding: 0 clamp(1rem, 5vw, 3rem);
-}
-
-a {
-	text-underline-offset: 0.15em;
+	padding: 0 var(--header-footer-padding-inline);
 }
 
 p {
@@ -107,6 +106,20 @@ p {
 
 a {
 	color: var(--text);
+	text-decoration-color: currentColor;
+	text-underline-offset: 0.15em;
+	transition:
+		color var(--animation-duration) ease-in-out,
+		text-decoration-color var(--animation-duration) ease-in-out;
+}
+
+a:hover {
+	text-decoration-color: var(--secondary);
+}
+
+a:focus-visible {
+	outline: var(--focus-outline-width) solid var(--focus-outline-color);
+	outline-offset: var(--focus-outline-offset);
 	text-decoration-color: var(--secondary);
 }
 
@@ -118,6 +131,8 @@ a {
 	margin: -1px;
 	overflow: hidden;
 	clip: rect(0, 0, 0, 0);
+	clip-path: inset(50%);
+	white-space: nowrap;
 	border: 0;
 }
 

--- a/apps/website/styles/variables.css
+++ b/apps/website/styles/variables.css
@@ -1,6 +1,10 @@
 :root {
 	--max-content-width: 1900px;
 	--line-height: 1.6;
+	--content-padding-inline: clamp(1.5rem, 4vw, 3rem);
+	--content-padding-block-start: clamp(1.5rem, 4vh, 3rem);
+	--content-padding-block-end: clamp(3rem, 8vh, 6rem);
+	--header-footer-padding-inline: clamp(1rem, 5vw, 3rem);
 
 	--text: #000000;
 	--bg: #ffffff;
@@ -31,4 +35,13 @@
 	--bp_mobile: 768px;
 
 	--animation-duration: 0.2s;
+	--focus-outline-color: var(--secondary);
+	--focus-outline-offset: 0.2rem;
+	--focus-outline-width: 0.15rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	:root {
+		--animation-duration: 0s;
+	}
 }


### PR DESCRIPTION
## Summary
- add layout spacing and focus custom properties and apply them to global typography and container styles
- replace deprecated grid-gap usage, tighten tag layout spacing, and add focus-visible handling on navigation and tags
- improve media handling by disabling fixed hero backgrounds on smaller screens, reducing hover motion on recipe cards, and honoring reduced-motion by zeroing animation duration

## Testing
- pnpm --filter website lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695747dfea648320bb51964416192d79)