### PR TITLE
chore: improve VS Code and Codespaces setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,46 @@
+{
+	"name": "Ryan Bakes",
+	"image": "mcr.microsoft.com/devcontainers/base:bookworm",
+	"features": {
+		"ghcr.io/devcontainers/features/node:1": {
+			"version": "22",
+			"pnpm": "true"
+		},
+		"ghcr.io/devcontainers/features/github-cli:1": {}
+	},
+	"mounts": ["source=ryan-bakes-pnpm-store,target=/home/node/.pnpm-store,type=volume"],
+	"postCreateCommand": "corepack enable && pnpm install --frozen-lockfile",
+	"updateContentCommand": "pnpm install --frozen-lockfile",
+	"remoteUser": "node",
+	"containerEnv": {
+		"NEXT_TELEMETRY_DISABLED": "1",
+		"SANITY_STUDIO_TELEMETRY_DISABLED": "1"
+	},
+	"forwardPorts": [3000, 3333],
+	"portsAttributes": {
+		"3000": {
+			"label": "Website",
+			"onAutoForward": "notify"
+		},
+		"3333": {
+			"label": "Sanity Studio",
+			"onAutoForward": "notify"
+		}
+	},
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"typescript.tsdk": "${containerWorkspaceFolder}/node_modules/typescript/lib",
+				"cSpell.configFile": "${containerWorkspaceFolder}/.vscode/cspell.json"
+			},
+			"extensions": [
+				"biomejs.biome",
+				"EditorConfig.EditorConfig",
+				"github.vscode-github-actions",
+				"redhat.vscode-yaml",
+				"sanity-io.vscode-sanity",
+				"streetsidesoftware.code-spell-checker"
+			]
+		}
+	}
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
 	"mounts": ["source=ryan-bakes-pnpm-store,target=/home/node/.pnpm-store,type=volume"],
 	"postCreateCommand": "corepack enable && pnpm install --frozen-lockfile",
 	"updateContentCommand": "pnpm install --frozen-lockfile",
-	"remoteUser": "node",
+	"remoteUser": "vscode",
 	"containerEnv": {
 		"NEXT_TELEMETRY_DISABLED": "1",
 		"SANITY_STUDIO_TELEMETRY_DISABLED": "1"

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -1,5 +1,5 @@
 {
-	"ignorePaths": ["git/**/*"],
+	"ignorePaths": ["**/node_modules/**", "**/.next/**", "**/.turbo/**", "**/.vercel/**", "git/**/*"],
 	"words": [
 		"autoapprove",
 		"clsx",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,9 +1,11 @@
 {
 	"recommendations": [
 		"biomejs.biome",
+		"streetsidesoftware.code-spell-checker",
 		"redhat.vscode-yaml",
 		"EditorConfig.EditorConfig",
-		"github.vscode-github-actions"
+		"github.vscode-github-actions",
+		"sanity-io.vscode-sanity"
 	],
 	"unwantedRecommendations": ["esbenp.prettier-vscode"]
 }

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,8 +1,8 @@
 {
 	"servers": {
 		"next-devtools": {
-			"command": "pnpm exec",
-			"args": ["-y", "next-devtools-mcp@latest"]
+			"command": "pnpm",
+			"args": ["dlx", "next-devtools-mcp@latest"]
 		}
 	}
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,7 +21,7 @@
 		"editor.defaultFormatter": "vscode.markdown-language-features"
 	},
 	"[typescript]": {
-		"editor.defaultFormatter": "vscode.typescript-language-features"
+		"editor.defaultFormatter": "biomejs.biome"
 	},
 	"[typescriptreact]": {
 		"editor.defaultFormatter": "biomejs.biome"
@@ -30,6 +30,7 @@
 		"editor.defaultFormatter": "redhat.vscode-yaml"
 	},
 	"biome.enabled": true,
+	"cSpell.configFile": ".vscode/cspell.json",
 	"editor.codeActionsOnSave": {
 		"source.fixAll.biome": "explicit",
 		"source.organizeImports.biome": "explicit"
@@ -56,6 +57,16 @@
 	},
 	"files.insertFinalNewline": true,
 	"files.trimTrailingWhitespace": true,
+	"files.watcherExclude": {
+		"**/.next": true,
+		"**/.nitro": true,
+		"**/.output": true,
+		"**/.sanity": true,
+		"**/.turbo": true,
+		"**/.vercel": true,
+		"**/dist": true,
+		"**/node_modules": true
+	},
 	"prettier.enable": false,
 	"prettier.requireConfig": true,
 	"search.exclude": {
@@ -68,5 +79,6 @@
 		"**/dist": true,
 		"**/node_modules": true
 	},
+	"typescript.enablePromptUseWorkspaceTsdk": true,
 	"typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,75 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "Dev: Website",
+			"type": "shell",
+			"command": "pnpm dev:website",
+			"options": {
+				"cwd": "${workspaceFolder}"
+			},
+			"presentation": {
+				"panel": "dedicated",
+				"reveal": "always"
+			},
+			"detail": "Start the Next.js dev server for the website on port 3000."
+		},
+		{
+			"label": "Dev: CMS",
+			"type": "shell",
+			"command": "pnpm dev:cms",
+			"options": {
+				"cwd": "${workspaceFolder}"
+			},
+			"presentation": {
+				"panel": "dedicated",
+				"reveal": "always"
+			},
+			"detail": "Start the Sanity Studio dev server on port 3333."
+		},
+		{
+			"label": "Typegen",
+			"type": "shell",
+			"command": "pnpm typegen",
+			"options": {
+				"cwd": "${workspaceFolder}"
+			},
+			"problemMatcher": [],
+			"detail": "Extract the Sanity schema and regenerate types."
+		},
+		{
+			"label": "Lint (Biome)",
+			"type": "shell",
+			"command": "pnpm lint",
+			"options": {
+				"cwd": "${workspaceFolder}"
+			},
+			"problemMatcher": [],
+			"detail": "Run Biome across the workspace."
+		},
+		{
+			"label": "Typecheck",
+			"type": "shell",
+			"command": "pnpm typecheck",
+			"options": {
+				"cwd": "${workspaceFolder}"
+			},
+			"problemMatcher": "$tsc",
+			"detail": "Run TypeScript checks across all packages."
+		},
+		{
+			"label": "CI Verify",
+			"type": "shell",
+			"command": "pnpm ci:verify",
+			"options": {
+				"cwd": "${workspaceFolder}"
+			},
+			"problemMatcher": [],
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"detail": "Mirror the CI verify pipeline locally."
+		}
+	]
+}


### PR DESCRIPTION
## Summary
- align VS Code formatters with Biome and configure cspell to use the shared dictionary
- add VS Code tasks for common workflows and tighten watcher exclusions
- add a Codespaces-ready devcontainer with Node 22, pnpm, and forwarded ports for the website and CMS

## Testing
- Not run (config-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69574ca02f908320bef0877a73f38c4c)