### PR TITLE
Add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+# Normalize text files to use LF in the repository and on checkout
+* text=auto eol=lf
+
+# Ensure common binary formats are left untouched
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.ico binary
+*.svg binary
+*.ttf binary
+*.otf binary
+*.woff binary
+*.woff2 binary
+*.mp4 binary
+*.mov binary
+*.pdf binary


### PR DESCRIPTION
## Summary
- add repository-level .gitattributes to normalize text files to LF
- mark common binary assets as binary to avoid unwanted conversions

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695751cbd0f883208ccf6665b4a0ff8c)