### PR TITLE
Stabilize Next typed routes output directory

### DIFF
--- a/apps/website/next.config.mjs
+++ b/apps/website/next.config.mjs
@@ -7,6 +7,7 @@ const __dirname = path.dirname(__filename);
 /** @type {import("next").NextConfig} */
 const nextConfig = {
 	reactStrictMode: true,
+	distDir: ".next",
 	outputFileTracingRoot: path.join(__dirname, "../../"),
 	images: {
 		remotePatterns: [{ protocol: "https", hostname: "cdn.sanity.io" }],

--- a/apps/website/tsconfig.json
+++ b/apps/website/tsconfig.json
@@ -15,5 +15,5 @@
 		]
 	},
 	"exclude": ["node_modules"],
-	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"]
+	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- set an explicit Next.js distDir so dev and production typed routes output to the same location
- align the website tsconfig includes with the single types output path

## Testing
- pnpm --filter website typecheck *(fails: missing @ryan-bakes/sanity-types / generated types in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957512c8554832099f2848e74c84b4c)