### PR TITLE
Align website imports with tsconfig aliases

### DIFF
--- a/apps/website/app/recipe/(components)/secondary-featured-recipes/index.tsx
+++ b/apps/website/app/recipe/(components)/secondary-featured-recipes/index.tsx
@@ -1,4 +1,4 @@
-import Heading from "components/generic/heading";
+import Heading from "@components/generic/heading";
 import "server-only";
 import SecondaryFeaturedRecipe from "./secondary-featured-recipe";
 import styles from "./secondary-featured-recipes.module.css";

--- a/apps/website/app/recipe/(components)/secondary-featured-recipes/secondary-featured-recipe.tsx
+++ b/apps/website/app/recipe/(components)/secondary-featured-recipes/secondary-featured-recipe.tsx
@@ -1,4 +1,4 @@
-import Card from "components/generic/card";
+import Card from "@components/generic/card";
 import getRecipeById from "queries/getRecipeById";
 import "server-only";
 

--- a/apps/website/app/recipe/[slug]/(components)/commentary/index.tsx
+++ b/apps/website/app/recipe/[slug]/(components)/commentary/index.tsx
@@ -1,4 +1,4 @@
-import PortableText from "components/generic/portableText";
+import PortableText from "@components/generic/portableText";
 import getRecipeBySlug from "queries/getRecipeBySlug";
 import "server-only";
 import type { Props } from "../../page";

--- a/apps/website/app/recipe/[slug]/(components)/hero/index.tsx
+++ b/apps/website/app/recipe/[slug]/(components)/hero/index.tsx
@@ -1,5 +1,5 @@
-import Heading from "components/generic/heading";
-import createImageBuilder from "hooks/useImageBuilder";
+import Heading from "@components/generic/heading";
+import createImageBuilder from "@hooks/useImageBuilder";
 import getRecipeBySlug from "queries/getRecipeBySlug";
 import type { CSSProperties } from "react";
 import "server-only";

--- a/apps/website/app/recipe/[slug]/(components)/ingredient-amount.tsx
+++ b/apps/website/app/recipe/[slug]/(components)/ingredient-amount.tsx
@@ -1,5 +1,5 @@
+import Fraction from "@components/generic/fraction";
 import type { Unit, UnitReference } from "@ryan-bakes/sanity-types";
-import Fraction from "components/generic/fraction";
 import "server-only";
 
 interface UnitDisplayProps {

--- a/apps/website/app/recipe/[slug]/(components)/ingredients/index.tsx
+++ b/apps/website/app/recipe/[slug]/(components)/ingredients/index.tsx
@@ -1,4 +1,4 @@
-import Heading from "components/generic/heading";
+import Heading from "@components/generic/heading";
 import getAllUnits from "queries/getAllUnits";
 import getRecipeBySlug from "queries/getRecipeBySlug";
 import "server-only";

--- a/apps/website/app/recipe/[slug]/(components)/step/index.tsx
+++ b/apps/website/app/recipe/[slug]/(components)/step/index.tsx
@@ -1,3 +1,5 @@
+import Block from "@components/generic/block";
+import Heading from "@components/generic/heading";
 import type {
 	Ingredient,
 	InlineImage,
@@ -7,8 +9,6 @@ import type {
 	Unit,
 } from "@ryan-bakes/sanity-types";
 import type Keyed from "@t/keyed";
-import Block from "components/generic/block";
-import Heading from "components/generic/heading";
 import "server-only";
 import IngredientAmount from "../ingredient-amount";
 import styles from "./step.module.css";

--- a/apps/website/app/recipe/[slug]/(components)/steps/index.tsx
+++ b/apps/website/app/recipe/[slug]/(components)/steps/index.tsx
@@ -1,4 +1,4 @@
-import Heading from "components/generic/heading";
+import Heading from "@components/generic/heading";
 import getAllUnits from "queries/getAllUnits";
 import getRecipeBySlug from "queries/getRecipeBySlug";
 import "server-only";

--- a/apps/website/app/recipe/page.tsx
+++ b/apps/website/app/recipe/page.tsx
@@ -1,6 +1,6 @@
-import FeaturedRecipe from "components/generic/featured-recipe";
-import Heading from "components/generic/heading";
-import PortableText from "components/generic/portableText";
+import FeaturedRecipe from "@components/generic/featured-recipe";
+import Heading from "@components/generic/heading";
+import PortableText from "@components/generic/portableText";
 import getRecipesPage from "queries/getRecipesPage";
 import "server-only";
 import SecondaryFeaturedRecipes from "./(components)/secondary-featured-recipes";

--- a/apps/website/app/tags/[slug]/page.tsx
+++ b/apps/website/app/tags/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import Heading from "components/generic/heading";
+import Heading from "@components/generic/heading";
 import Link from "next/link";
 import getAllTags from "queries/getAllTags";
 import getRecipesByTag from "queries/getRecipesByTag";

--- a/apps/website/components/generic/block-types/image-section.tsx
+++ b/apps/website/components/generic/block-types/image-section.tsx
@@ -1,6 +1,6 @@
+import throwError from "@helpers/throwError";
+import createImageBuilder from "@hooks/useImageBuilder";
 import type { InlineImage } from "@ryan-bakes/sanity-types";
-import throwError from "helpers/throwError";
-import createImageBuilder from "hooks/useImageBuilder";
 import Image from "next/image";
 import "server-only";
 

--- a/apps/website/components/generic/block-types/recipe-preview.tsx
+++ b/apps/website/components/generic/block-types/recipe-preview.tsx
@@ -1,7 +1,7 @@
 import FeaturedRecipe from "@components/generic/featured-recipe";
+import throwError from "@helpers/throwError";
 import type { RecipePreview } from "@ryan-bakes/sanity-types";
 import type Keyed from "@t/keyed";
-import throwError from "helpers/throwError";
 import "server-only";
 
 type Props = Readonly<{

--- a/apps/website/components/generic/block.tsx
+++ b/apps/website/components/generic/block.tsx
@@ -1,6 +1,6 @@
+import assertUnreachable from "@helpers/assertUnreachable";
 import type { InlineImage, RecipePreview, TextSection } from "@ryan-bakes/sanity-types";
 import type Keyed from "@t/keyed";
-import assertUnreachable from "helpers/assertUnreachable";
 import "server-only";
 import ImageSectionComponent from "./block-types/image-section";
 import RecipePreviewComponent from "./block-types/recipe-preview";

--- a/apps/website/components/generic/card/index.tsx
+++ b/apps/website/components/generic/card/index.tsx
@@ -1,7 +1,7 @@
+import Heading from "@components/generic/heading";
+import Image from "@components/generic/image";
+import Tags from "@components/generic/tags";
 import type { ImageWithAlt } from "@ryan-bakes/sanity-types";
-import Heading from "components/generic/heading";
-import Image from "components/generic/image";
-import Tags from "components/generic/tags";
 import Link from "next/link";
 import "server-only";
 import styles from "./card.module.css";

--- a/apps/website/components/generic/heading.tsx
+++ b/apps/website/components/generic/heading.tsx
@@ -1,5 +1,5 @@
+import assertUnreachable from "@helpers/assertUnreachable";
 import clsx from "clsx";
-import assertUnreachable from "helpers/assertUnreachable";
 import { type CSSProperties, createElement, type ReactNode } from "react";
 import "server-only";
 

--- a/apps/website/components/generic/image/index.tsx
+++ b/apps/website/components/generic/image/index.tsx
@@ -1,7 +1,7 @@
 "use client";
+import createImageBuilder from "@hooks/useImageBuilder";
 import type { ImageWithAlt } from "@ryan-bakes/sanity-types";
 import clsx from "clsx";
-import createImageBuilder from "hooks/useImageBuilder";
 import NextImage, { type ImageLoaderProps } from "next/image";
 import styles from "./image.module.css";
 

--- a/apps/website/components/generic/portableText.tsx
+++ b/apps/website/components/generic/portableText.tsx
@@ -1,3 +1,4 @@
+import Fraction from "@components/generic/fraction";
 import type {
 	PortableTextComponentProps,
 	PortableTextComponents,
@@ -6,7 +7,6 @@ import type {
 } from "@portabletext/react";
 import { PortableText as PortableTextComponent } from "@portabletext/react";
 import type { PortableTextBlock, TypedObject } from "@portabletext/types";
-import Fraction from "components/generic/fraction";
 import Link from "next/link";
 import type { ReactNode } from "react";
 import "server-only";

--- a/apps/website/components/menu/mainNavItem.tsx
+++ b/apps/website/components/menu/mainNavItem.tsx
@@ -1,4 +1,4 @@
-import assertUnreachable from "helpers/assertUnreachable";
+import assertUnreachable from "@helpers/assertUnreachable";
 import Link from "next/link";
 import type { NavItemQueryResult } from "queries/getNavItems";
 import styles from "./mainNavItem.module.css";

--- a/apps/website/hooks/useImageBuilder.ts
+++ b/apps/website/hooks/useImageBuilder.ts
@@ -1,5 +1,5 @@
 import type { SanityImageAssetReference } from "@ryan-bakes/sanity-types";
-import { clientEnv } from "shared/config/env.client";
+import { clientEnv } from "@shared/config/env.client";
 
 const sanityKey = clientEnv.NEXT_PUBLIC_SANITY_KEY;
 const dataset = clientEnv.NEXT_PUBLIC_SANITY_DATASET;

--- a/apps/website/queries/getAllRecipeSlugs.ts
+++ b/apps/website/queries/getAllRecipeSlugs.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { fetchSanity, groq } from "../shared/lib/sanity";
+import { fetchSanity, groq } from "@shared/lib/sanity";
 
 const allRecipeSlugsQuery = groq`*[_type == "recipe"]{ "slug": slug.current }`;
 

--- a/apps/website/queries/getAllTags.ts
+++ b/apps/website/queries/getAllTags.ts
@@ -1,7 +1,7 @@
+import Distinct from "@helpers/distinct";
 import type { Recipe } from "@ryan-bakes/sanity-types";
-import Distinct from "helpers/distinct";
 import "server-only";
-import { fetchSanity, groq } from "../shared/lib/sanity";
+import { fetchSanity, groq } from "@shared/lib/sanity";
 
 const allTagsQuery = groq`*[_type == "recipe"]{ tags }`;
 

--- a/apps/website/queries/getAllUnits.tsx
+++ b/apps/website/queries/getAllUnits.tsx
@@ -1,6 +1,6 @@
 import type { Unit } from "@ryan-bakes/sanity-types";
 import "server-only";
-import { fetchSanity, groq } from "../shared/lib/sanity";
+import { fetchSanity, groq } from "@shared/lib/sanity";
 
 const allUnitsQuery = groq`*[_type == "unit"] | order(name asc){...}`;
 

--- a/apps/website/queries/getHomepage.ts
+++ b/apps/website/queries/getHomepage.ts
@@ -1,5 +1,5 @@
+import throwError from "@helpers/throwError";
 import type { Page } from "@ryan-bakes/sanity-types";
-import throwError from "helpers/throwError";
 import "server-only";
 import getPageById from "./getPageById";
 import getSiteConfig from "./getSiteConfig";

--- a/apps/website/queries/getNavItems.ts
+++ b/apps/website/queries/getNavItems.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { fetchSanity, groq } from "../shared/lib/sanity";
+import { fetchSanity, groq } from "@shared/lib/sanity";
 
 export interface NavItemQueryResult {
 	id: string;

--- a/apps/website/queries/getPageById.ts
+++ b/apps/website/queries/getPageById.ts
@@ -1,7 +1,7 @@
+import throwError from "@helpers/throwError";
 import type { Page } from "@ryan-bakes/sanity-types";
-import throwError from "helpers/throwError";
 import "server-only";
-import { fetchSanity, groq } from "../shared/lib/sanity";
+import { fetchSanity, groq } from "@shared/lib/sanity";
 
 const pageByIdQuery = groq`*[_type == "page" && _id == $id][0]{...}`;
 

--- a/apps/website/queries/getRecipeById.ts
+++ b/apps/website/queries/getRecipeById.ts
@@ -1,7 +1,7 @@
+import throwError from "@helpers/throwError";
 import type { Recipe } from "@ryan-bakes/sanity-types";
-import throwError from "helpers/throwError";
 import "server-only";
-import { fetchSanity, groq } from "../shared/lib/sanity";
+import { fetchSanity, groq } from "@shared/lib/sanity";
 
 const recipeByIdQuery = groq`*[_type == "recipe" && _id == $id][0]{...}`;
 

--- a/apps/website/queries/getRecipeBySlug.ts
+++ b/apps/website/queries/getRecipeBySlug.ts
@@ -1,7 +1,7 @@
+import throwError from "@helpers/throwError";
 import type { Recipe } from "@ryan-bakes/sanity-types";
-import throwError from "helpers/throwError";
 import "server-only";
-import { fetchSanity, groq } from "../shared/lib/sanity";
+import { fetchSanity, groq } from "@shared/lib/sanity";
 
 const recipeBySlugQuery = groq`*[_type == "recipe" && slug.current == $slug][0]{...}`;
 

--- a/apps/website/queries/getRecipesByRecent.ts
+++ b/apps/website/queries/getRecipesByRecent.ts
@@ -1,7 +1,7 @@
+import { throwTypedError } from "@helpers/throwError";
 import type { Recipe } from "@ryan-bakes/sanity-types";
-import { throwTypedError } from "helpers/throwError";
 import "server-only";
-import { fetchSanity, groq } from "../shared/lib/sanity";
+import { fetchSanity, groq } from "@shared/lib/sanity";
 
 const recipesByRecentQuery = groq`*[_type == "recipe"] | order(_createdAt desc) [0...$count]{...}`;
 

--- a/apps/website/queries/getRecipesByTag.ts
+++ b/apps/website/queries/getRecipesByTag.ts
@@ -1,7 +1,7 @@
+import throwError from "@helpers/throwError";
 import type { Recipe } from "@ryan-bakes/sanity-types";
-import throwError from "helpers/throwError";
 import "server-only";
-import { fetchSanity, groq } from "../shared/lib/sanity";
+import { fetchSanity, groq } from "@shared/lib/sanity";
 
 const recipesByTagQuery = groq`*[_type == "recipe" && $tag in tags[]]{...}`;
 

--- a/apps/website/queries/getRecipesPage.ts
+++ b/apps/website/queries/getRecipesPage.ts
@@ -1,8 +1,8 @@
+import throwError from "@helpers/throwError";
 import type { RecipesPage } from "@ryan-bakes/sanity-types";
-import throwError from "helpers/throwError";
 import "server-only";
-import { serverEnv } from "shared/config/env.server";
-import { fetchSanity, groq } from "../shared/lib/sanity";
+import { serverEnv } from "@shared/config/env.server";
+import { fetchSanity, groq } from "@shared/lib/sanity";
 
 const recipesPageKey = serverEnv.RECIPES_PAGE_KEY;
 const recipesPageQuery = groq`*[_type == "recipesPage" && _id == $recipesPageKey][0]{...}`;

--- a/apps/website/queries/getSiteConfig.ts
+++ b/apps/website/queries/getSiteConfig.ts
@@ -1,8 +1,8 @@
+import throwError from "@helpers/throwError";
 import type { SiteConfig } from "@ryan-bakes/sanity-types";
-import throwError from "helpers/throwError";
 import "server-only";
-import { serverEnv } from "shared/config/env.server";
-import { fetchSanity, groq } from "../shared/lib/sanity";
+import { serverEnv } from "@shared/config/env.server";
+import { fetchSanity, groq } from "@shared/lib/sanity";
 
 const siteConfigKey = serverEnv.SITE_CONFIG_KEY;
 const siteConfigQuery = groq`*[_type == "siteConfig" && _id == $siteConfigKey][0]{...}`;

--- a/apps/website/queries/getTagsPage.ts
+++ b/apps/website/queries/getTagsPage.ts
@@ -1,8 +1,8 @@
+import throwError from "@helpers/throwError";
 import type { TagsPage } from "@ryan-bakes/sanity-types";
-import throwError from "helpers/throwError";
 import "server-only";
-import { serverEnv } from "shared/config/env.server";
-import { fetchSanity, groq } from "../shared/lib/sanity";
+import { serverEnv } from "@shared/config/env.server";
+import { fetchSanity, groq } from "@shared/lib/sanity";
 
 const tagsPageKey = serverEnv.TAGS_PAGE_KEY;
 const tagsPageQuery = groq`*[_type == "tagsPage" && _id == $tagsPageKey][0]{...}`;

--- a/apps/website/scripts/validate-env.ts
+++ b/apps/website/scripts/validate-env.ts
@@ -1,4 +1,4 @@
-import { ClientEnvSchema, ServerEnvSchema } from "@shared/config/env.schema";
+import { ClientEnvSchema, ServerEnvSchema } from "../shared/config/env.schema";
 
 // Parse using process.env so it matches Next build environment
 ClientEnvSchema.parse(process.env);

--- a/apps/website/scripts/validate-env.ts
+++ b/apps/website/scripts/validate-env.ts
@@ -1,4 +1,4 @@
-import { ClientEnvSchema, ServerEnvSchema } from "../shared/config/env.schema";
+import { ClientEnvSchema, ServerEnvSchema } from "@shared/config/env.schema";
 
 // Parse using process.env so it matches Next build environment
 ClientEnvSchema.parse(process.env);


### PR DESCRIPTION
## Summary
- standardize website imports to use the configured path aliases for components, hooks, helpers, and shared utilities
- update queries and scripts to consume shared path aliases for Sanity helpers and environment config

## Testing
- pnpm -w exec tsc -p apps/website/tsconfig.json --noEmit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958a4ac4ce083208afe29d9ac41f8cf)