### PR TITLE
chore(ci): export SANITY_STUDIO_GRAMS_UNIT_ID for CMS tooling

### DIFF
--- a/.github/actions/write-website-env/action.yml
+++ b/.github/actions/write-website-env/action.yml
@@ -49,3 +49,10 @@ runs:
         TAGS_PAGE_KEY=${{ inputs.tags_page_key }}
         SANITY_STUDIO_GRAMS_UNIT_ID=${{ inputs.sanity_studio_grams_unit_id }}
         EOF
+
+    - name: Export shared env vars
+      shell: bash
+      run: |
+        {
+          echo "SANITY_STUDIO_GRAMS_UNIT_ID=${{ inputs.sanity_studio_grams_unit_id }}"
+        } >> "$GITHUB_ENV"

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Required (example):
 NEXT_PUBLIC_BASE_URL=
 NEXT_PUBLIC_SANITY_KEY=
 NEXT_PUBLIC_SANITY_DATASET=
+SANITY_STUDIO_GRAMS_UNIT_ID=
 ```
 
 ### CI Variables
@@ -196,7 +197,8 @@ NEXT_PUBLIC_SANITY_DATASET=
 CI uses GitHub **repository variables** (not secrets) for build-time configuration.
 
 These values are non-sensitive identifiers (dataset names, document keys, etc.)
-and are written to `apps/website/.env` during CI.
+and are written to `apps/website/.env` during CI. `SANITY_STUDIO_GRAMS_UNIT_ID`
+is also exported for schema extraction in the CMS workflow (baker math validation).
 
 Sensitive credentials (e.g., deploy tokens) are stored as GitHub Secrets.
 


### PR DESCRIPTION
## Summary
- export SANITY_STUDIO_GRAMS_UNIT_ID through the env writer action so schema extraction and typegen can read it during CI
- document the grams unit id in the environment variable section for clarity on the CMS baker math requirement

## Testing
- pnpm -w exec biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off "README.md"

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695990d3256c8320aa5a320a76d932f8)