### PR TITLE
Fix tag links to preserve tag names with spaces

### DIFF
--- a/apps/website/components/ui/tag/index.tsx
+++ b/apps/website/components/ui/tag/index.tsx
@@ -8,9 +8,11 @@ type Props = Readonly<{
 }>;
 
 export default function Tag({ tag }: Props) {
+	const encodedTag = encodeURIComponent(tag);
+
 	return (
 		<li key={tag} className={styles.tagListItem}>
-			<Link className={styles.tagLink} href={`/tags/${tag.replace(" ", "-")}`}>
+			<Link className={styles.tagLink} href={`/tags/${encodedTag}`}>
 				<BiPurchaseTagAlt className={styles.tagLink_Svg} />
 				<span className={styles.tagLink_Tag}> {tag}</span>
 			</Link>


### PR DESCRIPTION
## Summary
- encode tag URLs with encodeURIComponent instead of manual space replacement
- keep tag links aligned with static params so tag pages resolve correctly

## Testing
- pnpm -w exec tsc -p apps/website/tsconfig.json --noEmit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695993fae47483208a7767dd75751128)