### PR TITLE
Improve accessibility for tag pages

### DIFF
--- a/apps/website/app/tags/[slug]/page.tsx
+++ b/apps/website/app/tags/[slug]/page.tsx
@@ -5,16 +5,20 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import "server-only";
 
+function formatTagTitle(slug: string): string {
+	return slug
+		.split("-")
+		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+		.join(" ");
+}
+
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
 	const resolvedParams = params instanceof Promise ? await params : params;
 	const { slug } = resolvedParams;
 
 	// convert slug to title case for metadata
 	// replace - with spaces
-	const title = slug
-		.split("-")
-		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-		.join(" ");
+	const title = formatTagTitle(slug);
 
 	const description = `Recipes tagged with "${title}"`;
 
@@ -31,33 +35,40 @@ export type Props = Readonly<{
 export default async function Tag({ params }: Props) {
 	const resolvedParams = params instanceof Promise ? await params : params;
 	const { slug } = resolvedParams;
+	const tagTitle = formatTagTitle(slug);
 
 	const recipes = await getRecipesByTag(slug);
 
 	return (
-		<>
-			<Heading level={3}>Tag: {slug}</Heading>
+		<main>
+			<div className="content">
+				<Heading level={2}>Tag: {tagTitle}</Heading>
 
-			<Heading level={4} sr>
-				Recipes
-			</Heading>
+				<Heading level={3} sr>
+					Recipes tagged with {tagTitle}
+				</Heading>
 
-			<ul>
-				{recipes.map(({ _id: id, title, slug: recipeSlug }) => {
-					const recipeSlugValue = recipeSlug?.current;
+				{recipes.length > 0 ? (
+					<ul>
+						{recipes.map(({ _id: id, title, slug: recipeSlug }) => {
+							const recipeSlugValue = recipeSlug?.current;
 
-					if (!recipeSlugValue) {
-						return null;
-					}
+							if (!recipeSlugValue) {
+								return null;
+							}
 
-					return (
-						<li key={id}>
-							<Link href={`/recipe/${recipeSlugValue}`}>{title ?? "Untitled"}</Link>
-						</li>
-					);
-				})}
-			</ul>
-		</>
+							return (
+								<li key={id}>
+									<Link href={`/recipe/${recipeSlugValue}`}>{title ?? "Untitled"}</Link>
+								</li>
+							);
+						})}
+					</ul>
+				) : (
+					<p>No recipes available for this tag yet.</p>
+				)}
+			</div>
+		</main>
 	);
 }
 

--- a/apps/website/app/tags/page.tsx
+++ b/apps/website/app/tags/page.tsx
@@ -1,15 +1,25 @@
+import Heading from "@components/ui/heading";
+import Tags from "@components/ui/tags";
+import getAllTags from "@queries/getAllTags";
 import type { Metadata } from "next";
+import "server-only";
 
 export const metadata: Metadata = {
 	title: "Tags",
 	description: "Browse all tags.",
 };
 
-export default function Page() {
+export default async function Page() {
+	const tags = await getAllTags();
+	const hasTags = tags.length > 0;
+
 	return (
 		<main>
 			<div className="content">
-				<p>TAGS PAGE</p>
+				<Heading level={2}>Tags</Heading>
+				<p>Browse recipes by tag.</p>
+
+				{hasTags ? <Tags tags={tags} /> : <p>No tags available yet.</p>}
 			</div>
 		</main>
 	);

--- a/apps/website/components/ui/tag/index.tsx
+++ b/apps/website/components/ui/tag/index.tsx
@@ -11,7 +11,7 @@ export default function Tag({ tag }: Props) {
 	return (
 		<li key={tag} className={styles.tagListItem}>
 			<Link className={styles.tagLink} href={`/tags/${tag.replace(" ", "-")}`}>
-				<BiPurchaseTagAlt className={styles.tagLink_Svg} />
+				<BiPurchaseTagAlt aria-hidden="true" focusable="false" className={styles.tagLink_Svg} />
 				<span className={styles.tagLink_Tag}> {tag}</span>
 			</Link>
 		</li>


### PR DESCRIPTION
## Summary
- render the tags index page with semantic headings and linked tag list for easier navigation
- wrap tag detail pages in main content regions, reuse human-friendly tag titles, and handle empty tag results
- mark decorative tag icons as hidden from assistive technology

## Testing
- pnpm run typecheck:website *(fails: missing generated @ryan-bakes/sanity-types module in the workspace)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695993ee50508320b4a9360fdd0cb551)