### PR TITLE
Enhance SEO metadata coverage

### DIFF
--- a/apps/website/app/layout.tsx
+++ b/apps/website/app/layout.tsx
@@ -14,16 +14,32 @@ export const viewport: Viewport = {
 };
 
 export async function generateMetadata(): Promise<Metadata> {
-	const { title } = await getSiteConfig();
-	const baseUrl = clientEnv.NEXT_PUBLIC_BASE_URL;
+	const { title, url } = await getSiteConfig();
+	const baseUrl = url ?? clientEnv.NEXT_PUBLIC_BASE_URL;
 
 	const defaultTitle = title ?? "Ryan Bakes";
+	const defaultDescription = "Browse Ryan Bakes recipes and baking tips.";
+	const metadataBase = baseUrl ? new URL(baseUrl) : undefined;
+
 	return {
 		title: {
 			template: `${defaultTitle} | %s`,
 			default: defaultTitle,
 		},
-		metadataBase: baseUrl ? new URL(baseUrl) : undefined,
+		description: defaultDescription,
+		metadataBase,
+		openGraph: {
+			type: "website",
+			url: metadataBase,
+			siteName: defaultTitle,
+			title: defaultTitle,
+			description: defaultDescription,
+		},
+		twitter: {
+			card: "summary_large_image",
+			title: defaultTitle,
+			description: defaultDescription,
+		},
 	};
 }
 

--- a/apps/website/app/layout.tsx
+++ b/apps/website/app/layout.tsx
@@ -30,7 +30,7 @@ export async function generateMetadata(): Promise<Metadata> {
 		metadataBase,
 		openGraph: {
 			type: "website",
-			url: metadataBase,
+			...(metadataBase && { url: metadataBase }),
 			siteName: defaultTitle,
 			title: defaultTitle,
 			description: defaultDescription,

--- a/apps/website/app/page.tsx
+++ b/apps/website/app/page.tsx
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
 	openGraph: {
 		title: homeTitle,
 		description: homeDescription,
-		url: homeCanonical,
+		...(homeCanonical ? { url: homeCanonical } : {}),
 	},
 	twitter: {
 		card: "summary_large_image",

--- a/apps/website/app/page.tsx
+++ b/apps/website/app/page.tsx
@@ -1,13 +1,29 @@
 import Block from "@components/features/content-blocks/block";
+import buildCanonicalUrl from "@helpers/build-canonical-url";
 import getHomepage from "@queries/getHomepage";
 import type { InlineImage, RecipePreview, TextSection } from "@ryan-bakes/sanity-types";
 import type Keyed from "@t/keyed";
 import type { Metadata } from "next";
 import "server-only";
 
+const homeCanonical = buildCanonicalUrl("/");
+const homeTitle = "Home";
+const homeDescription = "Browse Ryan Bakes recipes and baking tips.";
+
 export const metadata: Metadata = {
-	title: "Home",
-	description: "Browse Ryan Bakes recipes and baking tips.",
+	title: homeTitle,
+	description: homeDescription,
+	alternates: homeCanonical ? { canonical: homeCanonical } : undefined,
+	openGraph: {
+		title: homeTitle,
+		description: homeDescription,
+		url: homeCanonical,
+	},
+	twitter: {
+		card: "summary_large_image",
+		title: homeTitle,
+		description: homeDescription,
+	},
 };
 
 export default async function Page() {

--- a/apps/website/app/recipe/[slug]/page.tsx
+++ b/apps/website/app/recipe/[slug]/page.tsx
@@ -70,7 +70,7 @@ export async function generateMetadata({ params }: Readonly<Props>): Promise<Met
 			: undefined,
 		openGraph: {
 			type: "article",
-			url,
+			...(url ? { url } : {}),
 			title: recipeTitle,
 			description: ogDescription,
 			images: ogImage

--- a/apps/website/app/recipe/page.tsx
+++ b/apps/website/app/recipe/page.tsx
@@ -24,11 +24,11 @@ export async function generateMetadata(): Promise<Metadata> {
 					title,
 					description,
 					url: canonical,
-			  }
+				}
 			: {
 					title,
 					description,
-			  },
+				},
 		twitter: {
 			card: "summary_large_image",
 			title,

--- a/apps/website/app/recipe/page.tsx
+++ b/apps/website/app/recipe/page.tsx
@@ -1,6 +1,7 @@
 import FeaturedRecipe from "@components/features/recipe/featured-recipe";
 import Heading from "@components/ui/heading";
 import PortableText from "@components/ui/portable-text";
+import buildCanonicalUrl from "@helpers/build-canonical-url";
 import getRecipeById from "@queries/getRecipeById";
 import getRecipesPage from "@queries/getRecipesPage";
 import type { Recipe } from "@ryan-bakes/sanity-types";
@@ -8,10 +9,28 @@ import type { Metadata } from "next";
 import "server-only";
 import SecondaryFeaturedRecipes from "./features/secondary-featured-recipes";
 
-export const metadata: Metadata = {
-	title: "Recipes",
-	description: "Browse all recipes.",
-};
+export async function generateMetadata(): Promise<Metadata> {
+	const recipesPage = await getRecipesPage();
+	const title = recipesPage.title ?? "Recipes";
+	const description = "Browse all recipes.";
+	const canonical = buildCanonicalUrl("/recipe");
+
+	return {
+		title,
+		description,
+		alternates: canonical ? { canonical } : undefined,
+		openGraph: {
+			title,
+			description,
+			url: canonical,
+		},
+		twitter: {
+			card: "summary_large_image",
+			title,
+			description,
+		},
+	};
+}
 
 export default async function Page() {
 	const recipesPage = await getRecipesPage();

--- a/apps/website/app/recipe/page.tsx
+++ b/apps/website/app/recipe/page.tsx
@@ -19,11 +19,16 @@ export async function generateMetadata(): Promise<Metadata> {
 		title,
 		description,
 		alternates: canonical ? { canonical } : undefined,
-		openGraph: {
-			title,
-			description,
-			url: canonical,
-		},
+		openGraph: canonical
+			? {
+					title,
+					description,
+					url: canonical,
+			  }
+			: {
+					title,
+					description,
+			  },
 		twitter: {
 			card: "summary_large_image",
 			title,

--- a/apps/website/app/tags/[slug]/page.tsx
+++ b/apps/website/app/tags/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import Heading from "@components/ui/heading";
+import buildCanonicalUrl from "@helpers/build-canonical-url";
 import getAllTags from "@queries/getAllTags";
 import getRecipesByTag from "@queries/getRecipesByTag";
 import type { Metadata } from "next";
@@ -17,10 +18,23 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 		.join(" ");
 
 	const description = `Recipes tagged with "${title}"`;
+	const canonical = buildCanonicalUrl(`/tags/${slug}`);
 
 	return {
 		title,
 		description,
+		alternates: canonical ? { canonical } : undefined,
+		keywords: [slug],
+		openGraph: {
+			title,
+			description,
+			url: canonical,
+		},
+		twitter: {
+			card: "summary_large_image",
+			title,
+			description,
+		},
 	};
 }
 

--- a/apps/website/app/tags/[slug]/page.tsx
+++ b/apps/website/app/tags/[slug]/page.tsx
@@ -28,7 +28,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 		openGraph: {
 			title,
 			description,
-			url: canonical,
+			...(canonical ? { url: canonical } : {}),
 		},
 		twitter: {
 			card: "summary_large_image",

--- a/apps/website/app/tags/page.tsx
+++ b/apps/website/app/tags/page.tsx
@@ -16,7 +16,7 @@ export async function generateMetadata(): Promise<Metadata> {
 		openGraph: {
 			title,
 			description,
-			url: canonical,
+			...(canonical ? { url: canonical } : {}),
 		},
 		twitter: {
 			card: "summary_large_image",

--- a/apps/website/app/tags/page.tsx
+++ b/apps/website/app/tags/page.tsx
@@ -1,8 +1,8 @@
-import buildCanonicalUrl from "@helpers/build-canonical-url";
-import getTagsPage from "@queries/getTagsPage";
 import Heading from "@components/ui/heading";
 import Tags from "@components/ui/tags";
+import buildCanonicalUrl from "@helpers/build-canonical-url";
 import getAllTags from "@queries/getAllTags";
+import getTagsPage from "@queries/getTagsPage";
 import type { Metadata } from "next";
 import "server-only";
 

--- a/apps/website/app/tags/page.tsx
+++ b/apps/website/app/tags/page.tsx
@@ -1,9 +1,30 @@
+import buildCanonicalUrl from "@helpers/build-canonical-url";
+import getTagsPage from "@queries/getTagsPage";
 import type { Metadata } from "next";
 
-export const metadata: Metadata = {
-	title: "Tags",
-	description: "Browse all tags.",
-};
+export async function generateMetadata(): Promise<Metadata> {
+	const tagsPage = await getTagsPage();
+	const title = tagsPage.title ?? "Tags";
+	const featuredTag = tagsPage.featuredTag;
+	const description = featuredTag ? `Browse recipes tagged with ${featuredTag} and more.` : "Browse all tags.";
+	const canonical = buildCanonicalUrl("/tags");
+
+	return {
+		title,
+		description,
+		alternates: canonical ? { canonical } : undefined,
+		openGraph: {
+			title,
+			description,
+			url: canonical,
+		},
+		twitter: {
+			card: "summary_large_image",
+			title,
+			description,
+		},
+	};
+}
 
 export default function Page() {
 	return (

--- a/apps/website/helpers/build-canonical-url.ts
+++ b/apps/website/helpers/build-canonical-url.ts
@@ -1,0 +1,16 @@
+import { clientEnv } from "@shared/config/env.client";
+
+export default function buildCanonicalUrl(pathname: string, baseUrl?: string): string | undefined {
+	if (!pathname) {
+		return undefined;
+	}
+
+	const resolvedBaseUrl = baseUrl ?? clientEnv.NEXT_PUBLIC_BASE_URL;
+	const normalizedPath = pathname.startsWith("/") ? pathname : `/${pathname}`;
+
+	try {
+		return new URL(normalizedPath, resolvedBaseUrl).toString();
+	} catch {
+		return undefined;
+	}
+}


### PR DESCRIPTION
## Summary
- add a canonical URL helper and wire it through site metadata generation
- expand default metadata with Open Graph and Twitter defaults from site configuration
- include canonical URLs, social descriptions, and robots handling on recipe and tag pages

## Testing
- pnpm -w exec tsc -p apps/website/tsconfig.json --noEmit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695993e95e4c8320ba285dc8d75bb57e)