### PR TITLE
Refine static params generation from Sanity slugs

### DIFF
--- a/apps/website/app/recipe/[slug]/page.tsx
+++ b/apps/website/app/recipe/[slug]/page.tsx
@@ -15,13 +15,19 @@ import RecipeHero from "./features/hero";
 import RecipeIngredients from "./features/ingredients";
 import RecipeSteps from "./features/steps";
 
+type RouteParams = Readonly<{ slug: string }>;
+
 export type Props = Readonly<{
-	params: { slug: string } | Promise<{ slug: string }>;
+	params: RouteParams | Promise<RouteParams>;
 }>;
 
-export async function generateMetadata({ params }: Readonly<Props>): Promise<Metadata> {
+async function resolveParams(params: Props["params"]): Promise<RouteParams> {
 	const resolvedParams = params instanceof Promise ? await params : params;
-	const { slug } = resolvedParams;
+	return resolvedParams;
+}
+
+export async function generateMetadata({ params }: Readonly<Props>): Promise<Metadata> {
+	const { slug } = await resolveParams(params);
 
 	const recipe = await getRecipeBySlug(slug);
 
@@ -87,8 +93,7 @@ export async function generateMetadata({ params }: Readonly<Props>): Promise<Met
 }
 
 export default async function Page(props: Readonly<Props>) {
-	const resolvedParams = props.params instanceof Promise ? await props.params : props.params;
-	const { slug } = resolvedParams;
+	const { slug } = await resolveParams(props.params);
 
 	const [recipe, units] = await Promise.all([getRecipeBySlug(slug), getAllUnits()]);
 	const tags = recipe.tags ?? [];
@@ -112,7 +117,7 @@ export default async function Page(props: Readonly<Props>) {
 	);
 }
 
-export async function generateStaticParams() {
-	const ids = await getAllRecipeSlugs();
-	return ids.map((slug) => ({ slug }));
+export async function generateStaticParams(): Promise<RouteParams[]> {
+	const slugs = await getAllRecipeSlugs();
+	return slugs.map((slug) => ({ slug }));
 }

--- a/apps/website/app/tags/[slug]/page.tsx
+++ b/apps/website/app/tags/[slug]/page.tsx
@@ -12,16 +12,15 @@ export type Props = Readonly<{
 }>;
 
 async function resolveParams(params: Props["params"]): Promise<RouteParams> {
+	const resolvedParams = params instanceof Promise ? await params : params;
+	return resolvedParams;
+}
+
 function formatTagTitle(slug: string): string {
 	return slug
 		.split("-")
 		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
 		.join(" ");
-}
-
-export async function generateMetadata({ params }: Props): Promise<Metadata> {
-	const resolvedParams = params instanceof Promise ? await params : params;
-	return resolvedParams;
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {

--- a/apps/website/next-env.d.ts
+++ b/apps/website/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/website/queries/getAllRecipeSlugs.ts
+++ b/apps/website/queries/getAllRecipeSlugs.ts
@@ -1,3 +1,4 @@
+import Distinct from "@helpers/distinct";
 import "server-only";
 import { fetchSanity, groq } from "@shared/lib/sanity";
 
@@ -5,5 +6,7 @@ const allRecipeSlugsQuery = groq`*[_type == "recipe"]{ "slug": slug.current }`;
 
 export default async function getAllRecipeSlugs(): Promise<string[]> {
 	const result = await fetchSanity<{ slug?: string }[]>(allRecipeSlugsQuery, {}, { revalidate: 300, tags: ["recipe"] });
-	return result.flatMap(({ slug }) => (slug ? [slug] : []));
+	const slugs = result.map(({ slug }) => slug?.trim()).filter((slug): slug is string => Boolean(slug));
+
+	return Distinct(slugs);
 }

--- a/apps/website/queries/getAllTags.ts
+++ b/apps/website/queries/getAllTags.ts
@@ -7,6 +7,10 @@ const allTagsQuery = groq`*[_type == "recipe"]{ tags }`;
 
 export default async function getAllTags(): Promise<string[]> {
 	const recipes = await fetchSanity<Pick<Recipe, "tags">[]>(allTagsQuery, {}, { revalidate: 300, tags: ["recipe"] });
-	const tags = recipes.flatMap((recipe) => recipe.tags ?? []);
+	const tags = recipes
+		.flatMap((recipe) => recipe.tags ?? [])
+		.map((tag) => tag?.trim())
+		.filter((tag): tag is string => Boolean(tag));
+
 	return Distinct(tags);
 }


### PR DESCRIPTION
## Summary
- sanitize recipe and tag slug queries before generating static params
- add shared slug param resolution helpers for recipe and tag routes
- refresh the Next.js route type reference from the latest build output

## Testing
- pnpm run build:website *(fails: Sanity fetch endpoint unreachable with placeholder environment values)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69599edf51848320a3e5b80e558251d6)