### PR TITLE
Fix preview origin

### DIFF
--- a/apps/cms/sanity.config.ts
+++ b/apps/cms/sanity.config.ts
@@ -8,7 +8,8 @@ import { schemaTypes } from "./schemas";
 import { deskStructure } from "./structure";
 
 const dataset = process.env.SANITY_STUDIO_DATASET ?? "production";
-const previewOrigin = process.env.SANITY_STUDIO_PREVIEW_ORIGIN;
+
+const previewOrigin = process.env.NODE_ENV === "development" ? "http://localhost:3000" : "https://ryan-bakes.com";
 
 export default defineConfig({
 	name: "default",
@@ -21,12 +22,13 @@ export default defineConfig({
 		visionTool(),
 		presentationTool({
 			previewUrl: {
-				...(previewOrigin ? { initial: previewOrigin } : {}),
-				preview: "/",
+				initial: previewOrigin,
 				previewMode: {
-					enable: "/api/draft-mode/enable",
+					enable: `${previewOrigin}/api/draft-mode/enable`,
+					disable: `${previewOrigin}/api/draft-mode/disable`,
 				},
 			},
+			allowOrigins: ["http://localhost:3000", "https://ryan-bakes.com"],
 		}),
 		dashboardTool({
 			widgets: [projectInfoWidget(), projectUsersWidget()],

--- a/apps/cms/sanity.config.ts
+++ b/apps/cms/sanity.config.ts
@@ -8,7 +8,12 @@ import { schemaTypes } from "./schemas";
 import { deskStructure } from "./structure";
 
 const dataset = process.env.SANITY_STUDIO_DATASET ?? "production";
-const previewOrigin = process.env.SANITY_STUDIO_PREVIEW_ORIGIN;
+
+const previewOrigin = process.env.NODE_ENV === "development" ? "http://localhost:3000" : "https://ryan-bakes.com";
+
+const vercelPreviewOrigin = process.env.SANITY_STUDIO_VERCEL_PREVIEW_URL
+	? `https://${process.env.SANITY_STUDIO_VERCEL_PREVIEW_URL}`
+	: null;
 
 export default defineConfig({
 	name: "default",
@@ -21,12 +26,15 @@ export default defineConfig({
 		visionTool(),
 		presentationTool({
 			previewUrl: {
-				...(previewOrigin ? { initial: previewOrigin } : {}),
-				preview: "/",
+				initial: previewOrigin,
 				previewMode: {
-					enable: "/api/draft-mode/enable",
+					enable: `${previewOrigin}/api/draft-mode/enable`,
+					disable: `${previewOrigin}/api/draft-mode/disable`,
 				},
 			},
+			allowOrigins: ["http://localhost:3000", "https://ryan-bakes.com", vercelPreviewOrigin].filter(
+				Boolean,
+			) as string[],
 		}),
 		dashboardTool({
 			widgets: [projectInfoWidget(), projectUsersWidget()],

--- a/apps/website/app/api/draft-mode/disable/route.ts
+++ b/apps/website/app/api/draft-mode/disable/route.ts
@@ -1,0 +1,17 @@
+import { draftMode } from "next/headers";
+import { redirect } from "next/navigation";
+
+export const runtime = "nodejs";
+
+export async function GET(req: Request) {
+	const url = new URL(req.url);
+
+	// Turn off draft mode
+	const dm = await draftMode();
+	dm.disable();
+
+	// Optional redirect target (Sanity may include one)
+	const redirectTo = url.searchParams.get("redirect") ?? "/";
+
+	redirect(redirectTo);
+}

--- a/apps/website/next.config.mjs
+++ b/apps/website/next.config.mjs
@@ -12,6 +12,15 @@ const nextConfig = {
 	images: {
 		remotePatterns: [{ protocol: "https", hostname: "cdn.sanity.io" }],
 	},
+	async redirects() {
+		return [
+			{
+				source: "/studio",
+				destination: process.env.NEXT_PUBLIC_SANITY_STUDIO_URL,
+				permanent: false,
+			},
+		];
+	},
 };
 
 export default nextConfig;


### PR DESCRIPTION
This pull request improves the integration between the CMS studio and the website, focusing on environment-specific preview URLs, draft mode handling, and seamless navigation between the studio and website. The changes ensure that preview and draft mode features work correctly in both development and production environments.

**CMS Studio and Preview Configuration:**

- Updated `previewOrigin` in `sanity.config.ts` to use `http://localhost:3000` in development and `https://ryan-bakes.com` in production, with support for Vercel preview URLs.
- Enhanced the `presentationTool` configuration to:
  - Always set `initial` to the correct preview origin.
  - Set `previewMode.enable` and `previewMode.disable` URLs based on the environment.
  - Specify allowed origins for previews, including localhost, production, and Vercel preview URLs.

**Draft Mode API Handling:**

- Added a new API route `apps/website/app/api/draft-mode/disable/route.ts` to handle disabling draft mode and redirecting the user, supporting optional redirect targets from Sanity.

**Website Navigation and Redirects:**

- Updated `next.config.mjs` to add a redirect from `/studio` to the CMS studio URL defined in environment variables, improving navigation between the website and studio.